### PR TITLE
autoFill width and height

### DIFF
--- a/src/com/tripvi/drawerlayout/DrawerProxy.java
+++ b/src/com/tripvi/drawerlayout/DrawerProxy.java
@@ -33,6 +33,8 @@ public class DrawerProxy extends TiViewProxy {
 	@Override
 	public TiUIView createView(Activity activity) {
 		drawer = new Drawer(this);
+		drawer.getLayoutParams().autoFillsHeight = true;
+		drawer.getLayoutParams().autoFillsWidth = true;		
 		return drawer;
 	}
 	


### PR DESCRIPTION
automatically sets the Drawer `width`and `height` to `Ti.UI.FILL` instead of throwing an error if not set by user
