### PR TITLE
Update manifest to work with Titanium 6+

### DIFF
--- a/manifest
+++ b/manifest
@@ -1,5 +1,6 @@
-version: 1.1.1
-apiversion: 2
+version: 2.0.0
+apiversion: 3
+architectures: armeabi-v7a x86
 description: TiUIView adaptor for DrawerLayout
 author: metacortex
 license: MIT license
@@ -11,4 +12,4 @@ name: drawerlayout
 moduleid: com.tripvi.drawerlayout
 guid: f0a61bb9-3c4d-457f-84c7-3980a13e3dd2
 platform: android
-minsdk: 3.3.0
+minsdk: 6.0.0


### PR DESCRIPTION
This is a simple update to the manifest to work onTitanium 6.0.0+. Needs to be rebuilt against 6.0.0 SDK (just run ant from root after merging this PR).
